### PR TITLE
Setup Python virtual environment with an action

### DIFF
--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -1,0 +1,21 @@
+---
+name: Lint YAML code
+
+on:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
+jobs:
+  yamllint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: YAML Lint and Annotate
+        uses: Staffbase/yamllint-action@v1.1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          target-path: .

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,3 @@
+---
+rules:
+  truthy: disable

--- a/cleanup/action.yml
+++ b/cleanup/action.yml
@@ -1,3 +1,4 @@
+---
 name: 'Clean workspace'
 description: 'Clean workspace directory after previous workflow run'
 runs:

--- a/setup-venv/action.yml
+++ b/setup-venv/action.yml
@@ -1,0 +1,31 @@
+---
+name: 'Setup Python virtual environment'
+description: 'Install virtualenv and Python modules from requirements file'
+inputs:
+  venv-dir:
+    description: 'Virtualenv directory name'
+    required: true
+    default: 'venv'
+  requirements:
+    description: 'Path to requirements file'
+    required: true
+    default: requirements.txt
+runs:
+  using: "composite"
+  steps:
+    # Install virtualenv for current user
+    - shell: bash
+      run: |
+        if [ -z ~/.local/bin/virtualenv ]; then \
+          pip install --no-input --disable-pip-version-check --user virtualenv; \
+        fi
+
+    # Setup Python environment
+    - shell: bash
+      run: |
+        ~/.local/bin/virtualenv ${{ inputs.venv-dir }} && \
+        source ./${{ inputs.venv-dir }}/bin/activate && \
+        which python && \
+        python --version && \
+        pip install --no-input --disable-pip-version-check \
+        -r ${{ inputs.requirements }}

--- a/setup-venv/readme.md
+++ b/setup-venv/readme.md
@@ -1,0 +1,33 @@
+# Setup Python virtual environment
+
+Simple usage, given that the requirements file is called `requirements.txt`
+
+```yaml
+- uses: tarantool/actions/setup-venv@master
+```
+
+Providing the names of virtualenv directory and requirements file:
+
+```yaml
+- uses: tarantool/actions/setup-venv@master
+  with:
+    venv: '.venv'
+    requirements: 'requirements-test.txt'
+```
+
+Activate the virtual environment with:
+
+```bash
+source venv/bin/activate
+```
+
+This action is made as a (partial) replacement for
+https://github.com/actions/setup-python,
+particularly for using on ARM64 machines, where setup-python doesn't work.
+
+Sometimes we don't need to set up the exact version of Python, but rather
+need to set up a virtual environment and install a few packages in it.
+
+If `virtualenv` is not found in the system, this action will install it
+with `pip install --user`. This way it will not interfere with
+system Python packages.


### PR DESCRIPTION
Made as a (partial) replacement for https://github.com/actions/setup-python,
particularly for using on ARM64 machines, where setup-python doesn't work.

Sometimes we don't need to set up the exact version of Python, but rather
need to set up a virtual environment and install a few packages in it.

If `virtualenv` is not found in the system, this action will install it
with `pip install --user`. This way it will not interfere with
system Python packages.

Resolve #3 