### PR TITLE
Refine params of `update-submodule` action

### DIFF
--- a/update-submodule/README.md
+++ b/update-submodule/README.md
@@ -1,18 +1,27 @@
-# GitHub Action: Creates Pull Request when Submodules are Updated
+# GitHub Action: Create Pull Request for Submodule Update
 
-This action updates a submodule of the parent repository in a feature branch and opens a pull request against the main branch.
+This action updates a submodule of the target repository in a feature branch and 
+opens a pull request against the main branch to commit changes.
 
-If there is an open PR already, the action will just update and force-push the branch.
+If there is an open pull request already, the action will just force-push the 
+feature branch.
 
-## Variables
+## Parameters
 
-- `parent_repository` — full name of the repository which has the submodule: `<owner>/<repo>`.
-- `owner` — owner of the parent repository.
-- `checkout_branch` — the base branch in the parent repository.
-- `parent_branch_for_update` — base name for new branches, opened from the base branch in the parent repository.
-- `pr_against_branch` is the branch to open PR against; usually the same as `CHECKOUT_BRANCH`.
-- `pull_request_text` is used as the commit message, PR title, and PR body.
-- `github_token` — GitHub token of a user with `write` permissions in the target (parent) repository. Provide this token as an action secret.
+- `github_token` — the GitHub token of a user with `write` permissions in the 
+  target repository. Provide this token as an action secret.
+- `submodule` - the submodule path to update in the target repository; define a 
+  space-separated list to update a few submodules or leave empty to update all.
+- `repository` — the full name of the target repository: `<owner>/<repo>`.
+- `checkout_branch` — the target repository branch to checkout.
+- `feature_branch` — the target repository feature branch.
+- `pr_against_branch` - the target repository branch to open a pull request 
+  against; usually the same as `checkout_branch`.
+- `pr_title` - the title of the pull request; used as the pull request body 
+  as well.
+- `commit_user` - the user for the commit.
+- `commit_user_email` - the user email for the commit.
+- `commit_message` - the message for the commit.
 
 Example workflow:
 
@@ -27,32 +36,32 @@ on:
     - main
 
 jobs:
-  build:
+  submodule-update:
     name: Submodule update
     runs-on: docker
     env:
-      PARENT_REPOSITORY: 'org/repo'
+      SUBMODULE: 'sm'
+      REPOSITORY: 'org/repo'
       CHECKOUT_BRANCH: 'main'
+      FEATURE_BRANCH: 'update-submodule'
       PR_AGAINST_BRANCH: 'main'
-      PARENT_BRANCH_FOR_UPDATE: 'branch-for-update'
-      PULL_REQUEST_TEXT: 'Update submodule <name> on branch <checkout branch>'
-      OWNER: 'owner'
+      PR_TITLE: 'Update submodule <name> on branch <checkout branch>'
+      COMMIT_USER: SomeBot
+      COMMIT_USER_EMAIL: bot@example.com
+      COMMIT_MESSAGE: Bump submodule to new version
 
     steps:
-      - name: Checkout Code
-        uses: actions/checkout@v2
-
-      - name: run action
-        id: run_action
+      - name: Create PR with submodule update
         uses: tarantool/actions/update-submodule@master
         with:
-          github_token: ${{ secrets.PARENT_REPO_TOKEN }}
-          parent_repository: ${{ env.PARENT_REPOSITORY }}
+          github_token: ${{ secrets.GH_TOKEN }}
+          submodule: ${{ env.SUBMODULE }}
+          repository: ${{ env.REPOSITORY }}
           checkout_branch: ${{ env.CHECKOUT_BRANCH }}
+          feature_branch: ${{ env.FEATURE_BRANCH }}
           pr_against_branch: ${{ env.PR_AGAINST_BRANCH }}
-          parent_branch_for_update: ${{ env.PARENT_BRANCH_FOR_UPDATE }}
-          pull_request_text: ${{ env.PULL_REQUEST_TEXT }}
-          owner: ${{ env.OWNER }}
-          branch: ${{ github.head_ref || github.ref_name }}
-          current_repo: "${{ github.repository }}"
+          pr_title: ${{ env.PR_TITLE }}
+          commit_user: ${{ env.COMMIT_USER }}
+          commit_user_email: ${{ env.COMMIT_USER_EMAIL }}
+          commit_message: ${{ env.COMMIT_MESSAGE }}
 ```

--- a/update-submodule/action.yml
+++ b/update-submodule/action.yml
@@ -1,5 +1,9 @@
-name: 'Creates Pull Request when Submodules are Updated'
-description: 'This action updates a submodule of the parent repository in a feature branch and opens a pull request against the main branch.'
+name: 'Create Pull Request for Submodule Update'
+description: >
+  This action updates a submodule of the target repository in a feature branch
+  and opens a pull request against the main branch to commit changes. If there
+  is an open pull request already, the action will just force-push the feature
+  branch
 author: 'foxzi'
 
 branding:
@@ -8,75 +12,84 @@ branding:
 
 inputs:
   github_token:
-    description: 'Github Token'
+    description: >
+      The GitHub token of a user with `write` permissions in the target
+      repository. Provide this token as an action secret
+    required: true
+  submodule:
+    description: >
+      The submodule path to update in the target repository.
+      Define a space-separated list to update a few submodules or leave empty
+      to update all
+    required: false
+    default: ''
+  repository:
+    description: 'The full name of the target repository: <owner>/<repo>'
     required: true
   checkout_branch:
-    description: 'Branch to checkout'
+    description: 'The target repository branch to checkout'
     required: false
     default: 'master'
+  feature_branch:
+    description: 'The target repository feature branch'
+    required: false
+    default: 'bot/update-submodule'
   pr_against_branch:
-    description: 'Parent branch'
+    description: >
+      The target repository branch to open a pull request against.
+      Usually the same as `checkout_branch`
     required: true
-  parent_repository:
-    description: 'Parent Repository'
-    required: true
-  parent_branch_for_update:
-    description: 'Name for updating branch'
+  pr_title:
+    description: >
+      The title of the pull request. Used as the pull request body as well
     required: false
-    default: 'submodule_updates'
-  pull_request_text:
-    description: 'Text title of pull request'
+    default: '[Auto-generated] Update submodule'
+  commit_user:
+    description: 'The user for the commit'
+    default: 'TarantoolBot'
     required: false
-    default: 'Submodule updates'
-  owner:
-    description: 'Owner'
-    required: true
-  branch:
-    description: 'Current branch'
-    required: true
-  current_repo:
-    description: 'Current repository'
-    required: true
-  user_name:
-    description: "User name for commits"
-    default: "TarantoolBot"
-  user_email:
-    description: "Email for commits"
-    default: "bot@tarantool.io"
+  commit_user_email:
+    description: 'The user email for the commit'
+    default: 'bot@tarantool.io'
+    required: false
+  commit_message:
+    description: 'The message for the commit'
+    default: 'Update submodule'
+    required: false
 
 runs:
-  using: 'composite'
+  using: composite
   steps:
-  - name: Checkout parent repository and branch
+  - name: Checkout the target repository
     uses: actions/checkout@v2
     with:
       token: ${{ inputs.github_token }}
-      repository: ${{ inputs.parent_repository }}
+      repository: ${{ inputs.repository }}
       ref: ${{ inputs.checkout_branch }}
       submodules: true
       fetch-depth: 0
 
-  - name: Create new branch and push changes
+  - name: Create the new branch and push changes
     shell: bash
     run: |
-      git config user.name ${{ inputs.user_name }}
-      git config user.email ${{ inputs.user_email }}
-      git submodule update --remote
-      git checkout -b "${{ inputs.parent_branch_for_update }}-${{ inputs.branch }}"
-      git commit -am "updating submodules"
-      git push --set-upstream --force origin "${{ inputs.parent_branch_for_update }}-${{ inputs.branch }}"
+      git config user.name ${{ inputs.commit_user }}
+      git config user.email ${{ inputs.commit_user_email }}
+      git submodule update --remote ${{ inputs.submodule }}
+      git checkout -b "${{ inputs.feature_branch }}"
+      git commit -am "${{ inputs.commit_message }}"
+      git push --set-upstream --force origin "${{ inputs.feature_branch }}"
 
-  - name: Create pull request against target branch
+  - name: Create a pull request against the main branch
     uses: actions/github-script@v5
     with:
       github-token: ${{ inputs.github_token }}
       script: |
         await github.rest.pulls.create({
-          owner: '${{ inputs.owner }}',
-          repo: '${{ inputs.parent_repository }}'.split('/')[1].trim(),
-          head: "${{ inputs.parent_branch_for_update }}-${{ inputs.branch }}",
+          owner: '${{ inputs.repository }}'.split('/')[0].trim(),
+          repo: '${{ inputs.repository }}'.split('/')[1].trim(),
+          head: '${{ inputs.feature_branch }}',
           base: '${{ inputs.pr_against_branch }}',
-          title: '[Auto-generated] ${{ inputs.pull_request_text }} from ${{ inputs.current_repo }}@${{ inputs.branch }}',
-          body: '[Auto-generated] ${{ inputs.pull_request_text }} from ${{ inputs.current_repo }}@${{ inputs.branch }}',
+          title: '${{ inputs.pr_title }}',
+          body: '${{ inputs.pr_title }}',
         });
     continue-on-error: true

--- a/update-submodule/action.yml
+++ b/update-submodule/action.yml
@@ -60,36 +60,36 @@ inputs:
 runs:
   using: composite
   steps:
-  - name: Checkout the target repository
-    uses: actions/checkout@v2
-    with:
-      token: ${{ inputs.github_token }}
-      repository: ${{ inputs.repository }}
-      ref: ${{ inputs.checkout_branch }}
-      submodules: true
-      fetch-depth: 0
+    - name: Checkout the target repository
+      uses: actions/checkout@v2
+      with:
+        token: ${{ inputs.github_token }}
+        repository: ${{ inputs.repository }}
+        ref: ${{ inputs.checkout_branch }}
+        submodules: true
+        fetch-depth: 0
 
-  - name: Create the new branch and push changes
-    shell: bash
-    run: |
-      git config user.name ${{ inputs.commit_user }}
-      git config user.email ${{ inputs.commit_user_email }}
-      git submodule update --remote ${{ inputs.submodule }}
-      git checkout -b "${{ inputs.feature_branch }}"
-      git commit -am "${{ inputs.commit_message }}"
-      git push --set-upstream --force origin "${{ inputs.feature_branch }}"
+    - name: Create the new branch and push changes
+      shell: bash
+      run: |
+        git config user.name ${{ inputs.commit_user }}
+        git config user.email ${{ inputs.commit_user_email }}
+        git submodule update --remote ${{ inputs.submodule }}
+        git checkout -b "${{ inputs.feature_branch }}"
+        git commit -am "${{ inputs.commit_message }}"
+        git push --set-upstream --force origin "${{ inputs.feature_branch }}"
 
-  - name: Create a pull request against the main branch
-    uses: actions/github-script@v5
-    with:
-      github-token: ${{ inputs.github_token }}
-      script: |
-        await github.rest.pulls.create({
-          owner: '${{ inputs.repository }}'.split('/')[0].trim(),
-          repo: '${{ inputs.repository }}'.split('/')[1].trim(),
-          head: '${{ inputs.feature_branch }}',
-          base: '${{ inputs.pr_against_branch }}',
-          title: '${{ inputs.pr_title }}',
-          body: '${{ inputs.pr_title }}',
-        });
-    continue-on-error: true
+    - name: Create a pull request against the main branch
+      uses: actions/github-script@v5
+      with:
+        github-token: ${{ inputs.github_token }}
+        script: |
+          await github.rest.pulls.create({
+            owner: '${{ inputs.repository }}'.split('/')[0].trim(),
+            repo: '${{ inputs.repository }}'.split('/')[1].trim(),
+            head: '${{ inputs.feature_branch }}',
+            base: '${{ inputs.pr_against_branch }}',
+            title: '${{ inputs.pr_title }}',
+            body: '${{ inputs.pr_title }}',
+          });
+      continue-on-error: true


### PR DESCRIPTION
This patch refines parameters of the `update-submodule` action: removes
redundant and makes remaining consistent.

Also, it removes some hard-coded stuff (e.g PR title, commit message).
Now the PR title can be fully configured by users, the commit message
can be defined by users as well.

Also, now we can specify a submodule path that we would like to update.
Moreover, we can update a few or all submodules.

We should give users max flexibility on use of the action.