### PR TITLE
report-job-status: add default val for `job-steps`

### DIFF
--- a/report-job-status/README.md
+++ b/report-job-status/README.md
@@ -1,12 +1,12 @@
-# GitHub Action: report failed job to VK Team chat
+# GitHub Action: report failed job to VK Teams chat
 
-This action composes a message about the failed job and sends it to VK Teams chat.
-The message contains the following information:
+This action composes a message about the failed job and sends it to the 
+specified VK Teams chat. The message contains the following information:
 
 * __Job__: name of the failed job with the link to this job
 * __Commit__: hash of the commit that triggered the job with the link to this commit
 * __Branch__: name of the branch with the link to this branch
-* __History__: the link to commit history
+* __History__: link to the commit history
 * __Triggered on__: name of the event that triggered the job 
 * __Committer__: GitHub login of the commit author
 * __Commit message subject__: first line of the commit message

--- a/report-job-status/README.md
+++ b/report-job-status/README.md
@@ -30,7 +30,7 @@ steps:
 
 # Usage
 
-All the fields are required.
+Add the following code to the running steps:
 
 ```yaml
   - name: Send VK Teams notification

--- a/report-job-status/action.yml
+++ b/report-job-status/action.yml
@@ -12,8 +12,11 @@ inputs:
     description: 'Notification chat ID (or stamp from chat URL)'
     required: true
   job-steps:
-    description: 'Info about steps that have been run in the job'
+    description: >
+      Info about steps in JSON format that have been run in the job.
+      It must be always `ToJson(steps)` expression if you provide steps info
     required: false
+    default: '{}'
 
 runs:
   using: 'composite'

--- a/report-job-status/action.yml
+++ b/report-job-status/action.yml
@@ -63,9 +63,7 @@ runs:
           <b>Triggered on</b>: ${event}
           <b>Committer</b>: ${{ github.actor }}
           <b>Commit message subject</b>: ${commitString}
-          <code>
-          ${failedStepsMsg}
-          </code>`
+          <code>${failedStepsMsg}</code>`
           return message
         result-encoding: string
 

--- a/report-job-status/action.yml
+++ b/report-job-status/action.yml
@@ -1,5 +1,7 @@
-name: 'Report failed job to VK Team chat'
-description: 'This action composes a message about the failed job and sends it to VK Teams chat'
+name: 'Report failed job to VK Teams chat'
+description: >
+  This action composes a message about the failed job and sends it to
+  the specified VK Teams chat
 
 inputs:
   api-url:


### PR DESCRIPTION
When someone doesn't specify a value for the `job-steps` parameter,
the action fails with the `SyntaxError: Unexpected token 'const'` error.