### PR TITLE
report-job-status: improve inputs and code style

### DIFF
--- a/report-job-status/README.md
+++ b/report-job-status/README.md
@@ -1,20 +1,23 @@
 # GitHub Action: report failed job to VK Teams chat
 
-This action composes a message about the failed job and sends it to the 
+This action composes a message about the failed job and sends it to the
 specified VK Teams chat. The message contains the following information:
 
 * __Job__: name of the failed job with the link to this job
-* __Commit__: hash of the commit that triggered the job with the link to this commit
+* __Commit__: hash of the commit that triggered the job with the link to
+this commit
 * __Branch__: name of the branch with the link to this branch
 * __History__: link to the commit history
-* __Triggered on__: name of the event that triggered the job 
+* __Triggered on__: name of the event that triggered the job
 * __Committer__: GitHub login of the commit author
 * __Commit message subject__: first line of the commit message
-* __Failed steps info__: info about the failed steps (outputs, outcome, conclusion)
+* __Failed steps info__: info about the failed steps (outputs, outcome,
+conclusion)
 
 # Prepare your workflow
 
-The action can tell you about the failed steps only if your steps have IDs, for example:
+The action can tell you about the failed steps only if your steps have IDs,
+for example:
 
 ```yaml
 steps:

--- a/report-job-status/action.yml
+++ b/report-job-status/action.yml
@@ -5,13 +5,14 @@ description: >
 
 inputs:
   api-url:
-    description: 'Bot API URL'
-    required: true
+    description: Bot API URL
+    required: false
+    default: 'https://api.internal.myteam.mail.ru/bot/v1/'
   bot-token:
-    description: 'Bot token'
+    description: Bot token
     required: true
   chat-id:
-    description: 'Notification chat ID (or stamp from chat URL)'
+    description: Notification chat ID (or stamp from chat URL)
     required: true
   job-steps:
     description: >
@@ -21,7 +22,7 @@ inputs:
     default: '{}'
 
 runs:
-  using: 'composite'
+  using: composite
   steps:
     - name: Compose message about job failure
       id: compose-message
@@ -54,7 +55,8 @@ runs:
 
           Object.keys(steps).forEach(function(key) {
             if (steps[key]["conclusion"] == "failure") {
-              failedSteps += "\n" + String(key) + ": " + JSON.stringify(steps[key])
+              failedSteps += "\n" + String(key) + ": " + 
+                JSON.stringify(steps[key])
             }
           })
           if (failedSteps != "") {


### PR DESCRIPTION
This patch sets the default value for the `api-url` so the action
won't fail if credidentials for VK Teams are not set. Also this
patch improves code style (rule 80)