### PR TITLE
report-job-status: don't print commit str if empty

### DIFF
--- a/report-job-status/README.md
+++ b/report-job-status/README.md
@@ -51,4 +51,3 @@ Add the following code to the running steps:
 | bot-token | API token received from Metabot | 000.1234567890.0987654321:1111111111 |                            
 | chat-id   | Can be found in the chat info   | @tntcore_ghaction_chat               |
 | job-steps | Must be `${{ ToJson(steps) }}`  | ${{ ToJson(steps) }}                 |
-

--- a/report-job-status/action.yml
+++ b/report-job-status/action.yml
@@ -1,4 +1,4 @@
-name: 'Report failed job to VK Teams chat'
+name: Report failed job to VK Teams chat
 description: >
   This action composes a message about the failed job and sends it to
   the specified VK Teams chat

--- a/report-job-status/action.yml
+++ b/report-job-status/action.yml
@@ -82,8 +82,7 @@ runs:
           <b>${refType[0].toUpperCase()}${refType.slice(1)}</b>: <a href="${baseUrl}/${{ github.repository }}/${refTypeUrlPart}">${refName}</a>
           <b>History</b>: <a href="${baseUrl}/${{ github.repository }}/commits/${{ github.sha }}">commits</a>
           <b>Triggered on</b>: ${event}
-          <b>Committer</b>: ${{ github.actor }}
-          <b>Commit message subject</b>: ${commitString}
+          <b>Committer</b>: ${{ github.actor }}${commitString ? `\n<b>Commit message subject</b>: ${commitString}` : ""}
           <code>${failedStepsMsg}</code>`
           return message
         result-encoding: string


### PR DESCRIPTION
When a workflow is triggered on a pull request or schedule event,
the `${{ github.event.head_commit.message }}` expression is empty
and we have the empty value for the `Commit message subject` field
in the message:

    Job failed at tarantool/tarantool:
    Job: test
    Commit: a179a29bdee013afe8dfd6375d233f5a1e291d22
    Branch: 7494/merge
    History: commits
    Triggered on: pull_request
    Committer: ylobankov
    Commit message subject:

Now if the value is empty, it is omitted:

    Job failed at tarantool/tarantool:
    Job: test
    Commit: a179a29bdee013afe8dfd6375d233f5a1e291d22
    Branch: 7494/merge
    History: commits
    Triggered on: pull_request
    Committer: ylobankov