### PR TITLE
report-job-status: fix code example in README.md

### DIFF
--- a/report-job-status/README.md
+++ b/report-job-status/README.md
@@ -28,7 +28,6 @@ steps:
   - name: This step does some other useful work
     id: other-useful-work
     uses: some/additional/action@v1.0
-    run: other useful work
 ```
 
 # Usage


### PR DESCRIPTION
A job step cannot have both `run` and `uses`.