### PR TITLE
setup-venv: fix condition for virtualenv

### DIFF
--- a/setup-venv/action.yml
+++ b/setup-venv/action.yml
@@ -16,7 +16,7 @@ runs:
     # Install virtualenv for current user
     - shell: bash
       run: |
-        if [ -z ~/.local/bin/virtualenv ]; then \
+        if [ ! -f ~/.local/bin/virtualenv ]; then \
           pip install --no-input --disable-pip-version-check --user virtualenv; \
         fi
 


### PR DESCRIPTION
Fixes the following problem:
```
Run if [ -z ~/.local/bin/virtualenv ]; then \
Run ~/.local/bin/virtualenv venv && \
/opt/actions-runner/_work/_temp/50147462-f3e3-4a01-9605-3660a7d39edc.sh:
line 1: /root/.local/bin/virtualenv: No such file or directory
Error: Process completed with exit code 127.
```