### PR TITLE
 update-submodule: control PR creation with create_pr variable

### DIFF
--- a/update-submodule/README.md
+++ b/update-submodule/README.md
@@ -23,6 +23,7 @@ feature branch.
 - `commit_user_email` — the author's email of the new commit;
   default is `bot@tarantool.io`.
 - `commit_message` — the message for the commit; default is `Update submodule`.
+- `create_pr` — if `true` (default), create a pull request in the target repository.
 - `pr_against_branch` — the target repository branch to open a pull request 
   against; usually the same as `checkout_branch`; default is `master`.
 - `pr_title` — the title of the pull request;
@@ -56,7 +57,8 @@ gitGraph
   commit id:"commit_message" tag:"updates submodule"
 ```
 
-After pushing the branch, the action opens a pull request in the target repository:
+After pushing the branch, if input variable `create_pr` is `true`,
+the action opens a pull request in the target repository:
 
 ```mermaid
 %%{init: { 'gitGraph': {'mainBranchName': 'checkout_branch', 'diagramPadding': 30}} }%%

--- a/update-submodule/action.yml
+++ b/update-submodule/action.yml
@@ -35,6 +35,10 @@ inputs:
       The git ref to update the submodule to (branch, tag, or commit SHA)
     required: false
     default: 'master'
+  create_pr:
+    description: "Enable or disable creating a pull request"
+    required: false
+    default: 'true'
   pr_against_branch:
     description: >
       The target repository branch to open a pull request against.
@@ -90,6 +94,7 @@ runs:
         git push --force origin "${{ inputs.feature_branch }}"
 
     - name: Create a pull request against the main branch
+      if: inputs.create_pr == "true"
       uses: actions/github-script@v5
       with:
         github-token: ${{ inputs.github_token }}


### PR DESCRIPTION
Set variable `create_pr: false` to skip pull request creation.
Default value is `true`, to keep compatibility with workflows
that are already using this action.

Part of https://github.com/tarantool/sdk/issues/355