### PR TITLE
deps: update actions to use Node.js 16

### DIFF
--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: YAML Lint and Annotate
         uses: Staffbase/yamllint-action@v1.1.0

--- a/update-submodule/action.yml
+++ b/update-submodule/action.yml
@@ -70,7 +70,7 @@ runs:
   using: composite
   steps:
     - name: Checkout the target repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         token: ${{ inputs.github_token }}
         repository: ${{ inputs.repository }}
@@ -95,7 +95,7 @@ runs:
 
     - name: Create a pull request against the main branch
       if: inputs.create_pr == 'true'
-      uses: actions/github-script@v5
+      uses: actions/github-script@v6
       with:
         github-token: ${{ inputs.github_token }}
         script: |


### PR DESCRIPTION
Removes the following warning:

Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
Please update the following actions to use Node.js 16: actions/checkout@v2, actions/github-script@v5