### PR TITLE
update-submodule: return sha and sha7 in action's outputs

### DIFF
--- a/update-submodule/README.md
+++ b/update-submodule/README.md
@@ -30,6 +30,16 @@ feature branch.
   default is `[Auto-generated] Update submodule`.
 - `pr_description` — the description (body) of the pull request.
 
+## Outputs
+
+The action outputs SHA1 hashes of the new commit, created in the target repository:
+
+* `sha` — the full 40-character value. Example: `c5e10dfd6ec566d640e974986b8fbacaf717ae15`.
+* `sha7` — the shortened 7-character value, as often seen on GitHub. Example: `c5e10df`.
+
+To access the output values, assign an id to the step that is using this action.
+Then get the values like this: `${{ steps.<step-id>.outputs.sha }}`.
+
 ## How it works
 
 First, the action checks out the target repository and makes a `feature_branch`.
@@ -103,6 +113,7 @@ jobs:
     steps:
       - name: Create PR with submodule update
         uses: tarantool/actions/update-submodule@master
+        id: submodule-update
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           submodule: ${{ env.SUBMODULE }}
@@ -114,4 +125,9 @@ jobs:
           commit_user: ${{ env.COMMIT_USER }}
           commit_user_email: ${{ env.COMMIT_USER_EMAIL }}
           commit_message: ${{ env.COMMIT_MESSAGE }}
+
+      - name: Print SHA1 of the new commit
+        run: |
+          echo 'full: ${{ steps.submodule-update.outputs.sha }}'
+          echo 'short: ${{ steps.submodule-update.outputs.sha7 }}'
 ```

--- a/update-submodule/action.yml
+++ b/update-submodule/action.yml
@@ -65,6 +65,13 @@ inputs:
     description: 'The message for the commit'
     default: 'Update submodule'
     required: false
+outputs:
+  sha:
+    description: 'Full SHA1 of resulting commit'
+    value: ${{ steps.create-branch.outputs.sha }}
+  sha7:
+    description: 'Short SHA1 of resulting commit'
+    value: ${{ steps.create-branch.outputs.sha7 }}
 
 runs:
   using: composite
@@ -82,6 +89,7 @@ runs:
         fetch-depth: 0
 
     - name: Create the new branch and push changes
+      id: create-branch
       shell: bash
       run: |
         pushd ${{ inputs.submodule }}
@@ -95,6 +103,10 @@ runs:
         git checkout -b "${{ inputs.feature_branch }}"
         git commit -am "${{ inputs.commit_message }}"
         git push --force origin "${{ inputs.feature_branch }}"
+
+        # add new commit's SHA to action's outputs
+        echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+        echo "sha7=$(git rev-parse HEAD | head -c 7)" >> $GITHUB_OUTPUT
 
     - name: Create a pull request against the main branch
       if: inputs.create_pr == 'true'


### PR DESCRIPTION
See https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#outputs-for-composite-actions.

To access the output values, assign an id to the step that is using this action.
Then get the values like this: `${{ steps.<step-id>.outputs.sha }}`.

Resolves #40

---

Testing:  the following action step

```yml
      - name: Dump actions/update-submodule outputs
        run: echo '${{ toJSON(steps.create-branch.outputs) }}'
```

shows

```
{
  "sha": "846617ad9dad04f335feb24792ec57ce37200b62",
  "sha7": "846617a"
}
```