### PR TITLE
Actions get-pr-info and remove-git-ref

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 .idea
+# various examples of GitHub webhook payloads,
+# used for development
+**/example.json

--- a/get-pr-info/action.yml
+++ b/get-pr-info/action.yml
@@ -1,0 +1,89 @@
+name: Get information about a pull request
+description: >
+  This action provides information about a pull request,
+  analogous to `github.pull_request` context in workflows,
+  triggered by `pull_request` events
+
+inputs:
+  owner:
+    description: Repository owner
+    required: true
+  repo:
+    description: Repository name
+    required: true
+  pr_number:
+    description: Pull request number
+    required: true
+  token:
+    description: GitHub personal access token (PAT)
+    required: false
+    default: ${{ github.token }}
+  set-env:
+    description: Set environment variables
+    required: false
+    default: 'true'
+
+outputs:
+  base_repo:
+    description: Owner/name of the main repository, where the pull request is opened
+    value: ${{ fromJSON(steps.get-info.outputs.result).base_repo }}
+  base_ref:
+    description: The target branch of the pull request
+    value: ${{ fromJSON(steps.get-info.outputs.result).base_ref }}
+  base_sha:
+    description: The target branch HEAD commit's SHA
+    value: ${{ fromJSON(steps.get-info.outputs.result).base_sha }}
+  head_repo:
+    description: Owner/name of the repository with the feature branch
+    value: ${{ fromJSON(steps.get-info.outputs.result).head_repo }}
+  head_ref:
+    description: The feature branch of the pull request
+    value: ${{ fromJSON(steps.get-info.outputs.result).head_ref }}
+  head_sha:
+    description: The feature branch HEAD commit's SHA
+    value: ${{ fromJSON(steps.get-info.outputs.result).head_sha }}
+  merge_commit_sha:
+    description: SHA of the merge commit
+    value: ${{ fromJSON(steps.get-info.outputs.result).merge_commit_sha }}
+
+
+runs:
+  using: composite
+  steps:
+    - name: >
+        Fetch information about pull request #${{ inputs.pull_request_number }} 
+        in ${{ inputs.owner}}/${{ inputs.repo }}
+      id: get-info
+      uses: actions/github-script@v6
+      continue-on-error: false
+      with:
+        github-token: ${{ inputs.token }}
+        script: |
+          const response = await github.request('/repos/{owner}/{repo}/pulls/{pr_number}', {
+            owner: "${{ inputs.owner }}",
+            repo: "${{ inputs.repo }}",
+            pr_number: "${{ inputs.pr_number }}"
+          })
+          console.log(response.data)
+          const data = {
+            "base_repo": response.data.base.repo.full_name,
+            "base_ref": response.data.base.ref,
+            "base_sha": response.data.base.sha,
+            "head_repo": response.data.head.repo.full_name,
+            "head_ref": response.data.head.ref,
+            "head_sha": response.data.head.sha,
+            "merge_commit_sha": response.data.merge_commit_sha,
+          }
+          return data
+
+    - name: Set environment variables
+      if: inputs.set-env == 'true'
+      shell: bash
+      run: |
+        echo "BASE_REPO=${{ fromJSON(steps.get-info.outputs.result).base_repo }}" >> $GITHUB_ENV
+        echo "BASE_REF=${{ fromJSON(steps.get-info.outputs.result).base_ref }}" >> $GITHUB_ENV
+        echo "BASE_SHA=${{ fromJSON(steps.get-info.outputs.result).base_sha }}" >> $GITHUB_ENV
+        echo "HEAD_REPO=${{ fromJSON(steps.get-info.outputs.result).head_repo }}" >> $GITHUB_ENV
+        echo "HEAD_REF=${{ fromJSON(steps.get-info.outputs.result).head_ref }}" >> $GITHUB_ENV
+        echo "HEAD_SHA=${{ fromJSON(steps.get-info.outputs.result).head_sha }}" >> $GITHUB_ENV
+        echo "MERGE_COMMIT_SHA=${{ fromJSON(steps.get-info.outputs.result).merge_commit_sha }}" >> $GITHUB_ENV

--- a/get-pr-info/readme.md
+++ b/get-pr-info/readme.md
@@ -1,0 +1,60 @@
+# Get pull request information
+
+This action provides information about a pull request,
+analogous to `github.pull_request` context in workflows,
+triggered by `pull_request` events.
+
+## Usage
+
+```yaml
+- uses: tarantool/actions/get-pr-info@master
+  id: get-pr-info
+  with:
+    # Owner of the repository, where the pull request is opened.
+    # When working with repo forks, it is the main repo.
+    owner: ''
+    # Name of the repository, where the pull request is opened.
+    repo: ''
+    # Number of the pull request.
+    pr_number: 42
+    # Personal access token (PAT) used to access the GitHub API.
+    # Should have read permissions in the target repository.
+    # With public repositories or when the pull request is in the same repo
+    # as the workflow, ${{ github.token }} should be enough.
+    #
+    # Default: ${{ github.token }}
+    token: ''
+    # Whether to set the variables in the GitHub workflow environment,
+    # accessible via ${{ env.VAR_NAME }}.
+    # Note that existing variables will be overwritten.
+    # For details, see the outputs section.
+    #
+    # Default: 'true'
+    set-env: 'true'
+
+- name: Get results as step outputs or env variables
+  run: |
+    echo 'example'
+    echo '${{ steps.get-pr-info.outputs.merge_commit_sha }}'
+    echo '${{ env.MERGE_COMMIT_SHA }}'
+```
+
+## Outputs
+
+The action outputs a number of variables, similar to those in 
+the `github.pull_request` context. They are available as values
+in the `${{ steps.get-pr-info.outputs.* }}` variables and also as
+the environment variables, if `set-env` is set to `true`.
+
+* `base_repo`, `env.BASE_REPO`: owner/name of the main repository, 
+  where the pull request is opened.
+* `base_ref`, `env.BASE_REF`: the name of the target branch of the pull request,
+  for example, `master` or `main`.
+* `base_sha`, `env.BASE_SHA`: the target branch HEAD commit's SHA.
+* `head_repo`, `env.HEAD_REPO`: owner/name of the repository with the feature
+   branch; can be the same as `base_repo` or a fork repository.
+* `head_ref`, `env.HEAD_REF`: the name of the feature branch of the pull request.
+* `head_sha`, `env.HEAD_SHA`: the feature branch HEAD commit's SHA.
+* `merge_commit_sha`, `env.MERGE_COMMIT_SHA`: SHA of the merge commit that 
+  GitHub makes between the base and head branches in each mergeable pull request.
+  When base or head branches change, this commit changes as well.

--- a/remove-git-ref/action.yml
+++ b/remove-git-ref/action.yml
@@ -1,0 +1,36 @@
+name: Remove a git reference via GitHub API
+description: >
+  This action removes a git branch,
+  from a repository on GitHub with an API call.
+  It is a convenient way to remove temporary branches, like
+  those created by `tarantool/actions/update-submodule`.
+  
+  Note: removing tags is not supported yet.
+
+inputs:
+  owner:
+    description: Repository owner
+    required: true
+  repo:
+    description: Repository name
+    required: true
+  ref:
+    description: Git reference to remove
+  token:
+    description: GitHub personal access token (PAT)
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Remove reference ${{ inputs.ref }} from ${{ inputs.owner }}/${{ inputs.repo }}
+      uses: actions/github-script@v6
+      continue-on-error: true
+      with:
+        github-token: ${{ inputs.token }}
+        script: |
+          await github.request('DELETE /repos/{owner}/{repo}/git/refs/heads/{ref}', {
+            owner: "${{ inputs.owner }}",
+            repo: "${{ inputs.repo }}",
+            ref: "${{ inputs.ref }}"
+          })

--- a/remove-git-ref/readme.md
+++ b/remove-git-ref/readme.md
@@ -1,0 +1,24 @@
+# Remove git reference
+
+This action removes a git branch,
+from a repository on GitHub with an API call.
+It is a convenient way to remove temporary branches, like
+those created by `tarantool/actions/update-submodule`.
+
+Note: removing tags is not supported yet.
+
+## Usage
+
+```yaml
+- uses: tarantool/actions/remove-git-ref@master
+  with:
+    # Owner of the repository
+    owner: ''
+    # Name of the repository
+    repo: ''
+    # Name of the branch to remove, like `example` or `username/example`.
+    ref: ''
+    # Personal access token (PAT) used to access the GitHub API.
+    # Should have write permissions in the target repository.
+    token: ''
+```


### PR DESCRIPTION
# get-pr-info: get pull request information

Add the action for retrieving pull request context when it's not
available by default, like in `workflow_dispatch` events that work with
pull requests.

# remove-git-ref: remove branches in GitHub repositories

Add an action for removing branches and other refs in
GitHub repositories.

Part of https://github.com/tarantool/tarantool-qa/issues/296