### PR TITLE
update-submodule: always check out fetched ref

### DIFF
--- a/update-submodule/action.yml
+++ b/update-submodule/action.yml
@@ -94,7 +94,7 @@ runs:
       run: |
         pushd ${{ inputs.submodule }}
         git fetch origin ${{ inputs.update_to }}
-        git checkout ${{ inputs.update_to }}
+        git checkout FETCH_HEAD
         popd
 
         git config user.name ${{ inputs.commit_user }}


### PR DESCRIPTION
The `git checkout ${{ inputs.update_to }}` expression did not give us the desired result when the target repository was already checked out on a self-hosted runner because in this case we just checked out the local ref. Now we always check out fetched ref.

Fixes #44