### PR TITLE
report-job-status: add message about job matrix combination

### DIFF
--- a/report-job-status/action.yml
+++ b/report-job-status/action.yml
@@ -20,6 +20,12 @@ inputs:
       It must be always `ToJson(steps)` expression if you provide steps info
     required: false
     default: '{}'
+  matrix:
+    description: >
+      Info about the job's matrix context in JSON format.
+      It must always be the `ToJson(matrix)` expression.
+    required: false
+    default: '{}'
   job-name:
     description: >
       Full job name with matrix combinations. For example, job `test` with
@@ -69,6 +75,7 @@ runs:
           const eventNumber = "${{ github.event.number }}"
           const failedJobName = "${{ inputs.job-name }}" || "${{ github.job }}"
           const steps = ${{ inputs.job-steps }}
+          const matrix = ${{ inputs.matrix }}
           const jobContext = ${{ env.JOB_CONTEXT }}
 
           let refName = ""
@@ -76,6 +83,7 @@ runs:
           let refTypeUrlPart = ""
           let failedSteps = ""
           let failedStepsMsg = ""
+          let matrixMsg = ""
           let jobId = ""
           let jobIdMsg = ""
           
@@ -106,6 +114,10 @@ runs:
             }
           })
 
+          Object.keys(matrix).forEach(function(key) {
+            matrixMsg += `<li>${key}: ${matrix[key]}</li>`
+          })
+          
           // Try to find the job ID by its name.
           // In matrix workflows it will work only if exact name was provided
           // in `job-name` input.
@@ -127,7 +139,8 @@ runs:
           }
           
           let message = `🔴 FAIL
-          ${jobIdMsg}
+          ${jobIdMsg}\
+          ${matrixMsg ? `\n<b>Matrix combination:</b><ul>${matrixMsg}</ul>`: ""}
           <b>Workflow:</b> <a href="${baseUrl}/${{ github.repository }}/actions/runs/${{ github.run_id }}">${{ github.workflow }}</a>
           <b>Repo:</b> <a href="${baseUrl}/${{ github.repository }}/">${{ github.repository }}</a>
           <b>${refType[0].toUpperCase()}${refType.slice(1)}</b>: <a href="${baseUrl}/${{ github.repository }}/${refTypeUrlPart}">${refName}</a>


### PR DESCRIPTION
# Examples:

<img width="854" alt="Screenshot 2022-12-21 at 17 41 06" src="https://user-images.githubusercontent.com/8015154/208897267-e4b2e931-0408-42b6-8820-4269e8eefe51.png">

---

<img width="855" alt="Screenshot 2022-12-21 at 18 23 18" src="https://user-images.githubusercontent.com/8015154/208908838-a27ef998-0dbf-41d8-a4fb-465b46e65a9d.png">

