### PR TITLE
report-job-status: improve docs on matrix strategy

### DIFF
--- a/report-job-status/README.md
+++ b/report-job-status/README.md
@@ -45,12 +45,12 @@ Add the following code to the running steps:
       chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
       job-steps: ${{ ToJson(steps) }}
 ```
-| variable  | how to get                      | example                              |
-|-----------|---------------------------------|--------------------------------------|
-| api-url   | `/help` in Metabot              | https://myteam.mail.ru/bot/v1        |
-| bot-token | API token received from Metabot | 000.1234567890.0987654321:1111111111 |                            
-| chat-id   | Can be found in the chat info   | @tntcore_ghaction_chat               |
-| job-steps | Must be `${{ ToJson(steps) }}`  | ${{ ToJson(steps) }}                 |
+| variable  | how to get                      | example                                |
+|-----------|---------------------------------|----------------------------------------|
+| api-url   | `/help` in Metabot              | https://myteam.mail.ru/bot/v1          |
+| bot-token | API token received from Metabot | `000.1234567890.0987654321:1111111111` |                            
+| chat-id   | Can be found in the chat info   | `tntcore_ghaction_chat`                |
+| job-steps | Must be `${{ ToJson(steps) }}`  | `${{ ToJson(steps) }}`                 |
 
 ## Usage with matrix strategy
 
@@ -66,5 +66,11 @@ Provide this name in the `job-name` input variable:
   with:
     bot-token: ${{ secrets.VKTEAMS_BOT_TOKEN }}
     chat-id: ${{ secrets.VKTEAMS_CHAT_ID }}
-    job-name: "${{ github.job }} (${{ matrix.foo }})"
+    job-name: "${{ github.job }} (${{ join(matrix.*, ', ') }})"
 ```
+
+For this syntax to work, matrix parameters should not be equal to empty strings.
+Instead, just skip values, as shown in the [matrix strategy documentation](
+https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs#expanding-or-adding-matrix-configurations).
+GitHub skips empty strings when making a job name, but the 
+`join(matrix.*, ', ')` expression does not skip them.


### PR DESCRIPTION
Add an example of setting the `job-name` directly
from the `matrix` context, describe the requirements.

Also, slightly format the example values and remove
the misleading `@` from the `chat-id` example.

Preview: https://github.com/tarantool/actions/tree/nickvolynkin/report-job-status-matrix-usage/report-job-status#basic-usage