### PR TITLE
report-job-status: change setting output in steps

### DIFF
--- a/report-job-status/action.yml
+++ b/report-job-status/action.yml
@@ -34,7 +34,7 @@ runs:
   steps:
     - name: Prepare commit message
       id: prepare-commit-msg
-      run: echo "::set-output name=commit-msg::${COMMIT_MSG//'`'/<BACKTICK>}"
+      run: echo "commit-msg=${COMMIT_MSG//'`'/<BACKTICK>}" >> $GITHUB_OUTPUT
       env:
         COMMIT_MSG: |
           ${{ github.event.head_commit.message }}


### PR DESCRIPTION
The approach

  - name: Set output run: echo "::set-output name={name}::{value}"

is deprecated [1].

Switching to the new approach:

  - name: Set output run: echo "{name}={value}" >> $GITHUB_OUTPUT

[1] https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/