### PR TITLE
report-job-status: fix setting output in steps - part 2

### DIFF
--- a/report-job-status/action.yml
+++ b/report-job-status/action.yml
@@ -34,7 +34,10 @@ runs:
   steps:
     - name: Prepare commit message
       id: prepare-commit-msg
-      run: echo "commit-msg=${COMMIT_MSG//'`'/<BACKTICK>}" >> $GITHUB_OUTPUT
+      run: |
+        echo "commit-msg<<EOF" >> $GITHUB_OUTPUT
+        echo "${COMMIT_MSG//'`'/<BACKTICK>}" >> $GITHUB_OUTPUT
+        echo "EOF" >> $GITHUB_OUTPUT
       env:
         COMMIT_MSG: |
           ${{ github.event.head_commit.message }}


### PR DESCRIPTION
The new approach for returning an output from workflow steps works with multiline values differently, and we got the following error:

    Error: Unable to process file command 'output' successfully.

Now it is fixed.