### PR TITLE
update-submodule: not fail when nothing to commit

### DIFF
--- a/update-submodule/action.yml
+++ b/update-submodule/action.yml
@@ -101,6 +101,10 @@ runs:
         git config user.email ${{ inputs.commit_user_email }}
 
         git checkout -b "${{ inputs.feature_branch }}"
+        if [[ $(git status) =~ .*"nothing to commit".* ]]; then 
+          echo "status=nothing-to-commit" >> $GITHUB_OUTPUT
+          exit 0
+        fi
         git commit -am "${{ inputs.commit_message }}"
         git push --force origin "${{ inputs.feature_branch }}"
 
@@ -109,7 +113,8 @@ runs:
         echo "sha7=$(git rev-parse HEAD | head -c 7)" >> $GITHUB_OUTPUT
 
     - name: Create a pull request against the main branch
-      if: inputs.create_pr == 'true'
+      if: inputs.create_pr == 'true' &&
+        steps.create-branch.outputs.status != 'nothing-to-commit'
       uses: actions/github-script@v6
       with:
         github-token: ${{ inputs.github_token }}


### PR DESCRIPTION
Sometimes a submodule may be updated by somebody manually, bypassing the action. In such cases the following error occures when the action is running:

    On branch <branch name>
    nothing to commit, working tree clean

This patch fixes the problem.