### PR TITLE
check-module-version: add custom rock make opts

### DIFF
--- a/check-module-version/README.md
+++ b/check-module-version/README.md
@@ -11,6 +11,7 @@ This action is supposed to work on tag push event only.
 - `version-pre-extraction-hook` — the string with Lua code.
   Executed before extracting the version value from _VERSION variable.
   The hook code should not output to STDERR or STDOUT.
+- `rock-make-opts` — the rock make options.
 
 ## Example workflow:
 
@@ -31,6 +32,8 @@ jobs:
           module-name: 'foobar'
           # Lua code that does not output to STDERR or STDOUT.
           version-pre-extraction-hook: '...'
+          # Rock make options, e.g. STATIC_BUILD=ON.
+          rock-make-opts: '...'
 
   package:
     runs-on: ...

--- a/check-module-version/action.yml
+++ b/check-module-version/action.yml
@@ -12,6 +12,10 @@ inputs:
     description: Lua code executed before extracting the version value from _VERSION variable
     required: false
     default: ''
+  rock-make-opts:
+    description: Rock make options
+    required: false
+    default: ''
 
 runs:
   using: composite
@@ -27,7 +31,7 @@ runs:
         tarantool-version: '2.10'
 
     - name: Make rock
-      run: tarantoolctl rocks make
+      run: tarantoolctl rocks ${{ inputs.rock-make-opts }} make
       shell: bash
 
     - name: Check package version


### PR DESCRIPTION
Added the ability to specify a custom rock make opts via new `inputs.rock-make-opts` action parameter. For example, some packages require command `tarantoolctl rocks STATIC_BUILD=ON make` instead of `tarantoolctl rocks make`.

Is part of the task [1].

1. github.com/tarantool/roadmap-internal/issues/204