### PR TITLE
s3-copy: add action to save files to S3

### DIFF
--- a/get-job-id/README.md
+++ b/get-job-id/README.md
@@ -1,0 +1,29 @@
+# GitHub Action: get the current job ID
+
+There are several situations when we need the Job ID, but the GitHub
+doesn't give the context with the Job ID. This action gets the Job ID
+from the jobs' context (info about all the jobs in the run) with job
+name and run attempt. 
+
+The result will be saved in the environmental variable `JOB_ID` and as
+the action output `job-id`.
+
+# Usage
+```yaml
+    - name: Get job ID
+      uses: tarantool/actions/get-job-id@master
+      with:
+        job-name: ${{ github.job }} (${{ join(matrix.*, ', ') }})
+
+    - name: Use job ID
+      run: echo ${{ env.JOB_ID }}
+```
+
+# Parameters
+This action uses the only one parameter - `job-name`. You should set this
+parameter if your workflow uses matrix strategy. Don't worry if one of the
+parameters is the empty string: the action will remove empty brackets from
+the job name.
+
+If the `job-name` is empty, the action will use ${{ github.job }} to find the
+job ID.

--- a/get-job-id/action.yml
+++ b/get-job-id/action.yml
@@ -1,0 +1,74 @@
+name: Get job ID
+description: Get job ID
+
+inputs:
+  job-name:
+    description: >
+      Full job name with matrix combinations. For example, job `test` with
+      matrix options `foo='a'` and `bar='b'` will be named `test (a, b)`.
+      This is required for finding exact job IDs of matrix jobs.
+    required: false
+    default: ''
+  throw-error:
+    description: True, if the action shoul exit with error if can't get job ID.
+    required: false
+    default: 'false'
+outputs:
+  job-id:
+    description: ID of the current job.
+    value: ${{ steps.save-job-id.outputs.job-id }}
+
+runs:
+  using: composite
+  steps:
+    - name: Get job data
+      shell: bash
+      env:
+        CURL_COMMAND: |-
+          curl --location \
+            --fail \
+            --silent \
+            --show-error \
+            --retry 5 \
+            --retry-delay 5
+        API_RUNS: >-
+          https://api.github.com/repos/${{ github.repository }}/actions/runs
+      run: |
+        echo 'Fetching job data'
+        echo 'JOB_CONTEXT<<EOF' >> $GITHUB_ENV
+        ${{ env.CURL_COMMAND }} -H 'authorization: Bearer ${{ github.token }}' \
+          ${{ env.API_RUNS }}/${{ github.run_id }}/jobs >> $GITHUB_ENV
+        echo 'EOF' >> $GITHUB_ENV
+
+    - name: Get job ID
+      id: get-job-id
+      uses: actions/github-script@v6
+      with:
+        script: |
+          const jobContext = ${{ env.JOB_CONTEXT }}
+          const jobAttempt = ${{ github.run_attempt }}
+          let jobName = "${{ inputs.job-name }}" || "${{ github.job }}"
+          
+          if (jobName == "${{ github.job }} ()") {
+            jobName = "${{ github.job }}"
+          }
+            
+          // Try to find the job ID by its name.
+          // In matrix workflows will work only if exact name was provided
+          // in `job-name` input.
+          for (job of jobContext.jobs) {
+            if (job.name == jobName && job.run_attempt == ${{ github.run_attempt }}) {
+              return job.id
+            }
+          }
+          if (${{ inputs.throw-error }}) {
+            throw new Error('Unable to get job ID')
+          }
+        result-encoding: string
+
+    - name: Save job ID
+      id: save-job-id
+      shell: bash
+      run: |
+        echo 'JOB_ID=${{ steps.get-job-id.outputs.result }}' >> $GITHUB_ENV
+        echo 'job-id=${{ steps.get-job-id.outputs.result }}' >> $GITHUB_OUTPUT

--- a/report-job-status/action.yml
+++ b/report-job-status/action.yml
@@ -44,23 +44,10 @@ runs:
       shell: bash
 
     - name: Get job data
-      shell: bash
-      env:
-        CURL_COMMAND: |-
-          curl --location \
-            --fail \
-            --silent \
-            --show-error \
-            --retry 5 \
-            --retry-delay 5
-        API_ROOT: >-
-          https://api.github.com/repos/${{ github.repository }}/actions/runs
-      run: |
-        echo 'Fetching job data'
-        echo 'JOB_CONTEXT<<EOF' >> $GITHUB_ENV
-        ${{ env.CURL_COMMAND }} -H 'authorization: Bearer ${{ github.token }}' \
-          ${{ env.API_ROOT }}/${{ github.run_id }}/jobs >> $GITHUB_ENV
-        echo 'EOF' >> $GITHUB_ENV
+      uses: tarantool/actions/get-job-id@master
+      with:
+        job-name: ${{ inputs.job-name }}
+        throw-error: false
 
     - name: Compose message about job failure
       id: compose-message
@@ -72,14 +59,13 @@ runs:
           const eventNumber = "${{ github.event.number }}"
           const failedJobName = "${{ inputs.job-name }}" || "${{ github.job }}"
           const steps = ${{ inputs.job-steps }}
-          const jobContext = ${{ env.JOB_CONTEXT }}
+          const jobId = ${{ env.JOB_ID }}
 
           let refName = ""
           let refType = ""
           let refTypeUrlPart = ""
           let failedSteps = ""
           let failedStepsMsg = ""
-          let jobId = ""
           let jobIdMsg = ""
           
           if (eventName == "pull_request") {
@@ -109,16 +95,7 @@ runs:
             }
           })
 
-          // Try to find the job ID by its name.
-          // In matrix workflows it will work only if exact name was provided
-          // in `job-name` input.
-          for (job of jobContext.jobs) {
-            if (job.name == failedJobName) {
-              jobId = job.id
-              break
-            }
-          } 
-          if (jobId != "") {
+          if (jobId != undefined) {
             jobIdMsg = `<b>Job:</b> <a href="${baseUrl}/${{ github.repository }}/runs/${jobId}?check_suite_focus=true">${failedJobName}</a>, attempt #${{ github.run_attempt }}`
           } else {
             jobIdMsg = `<b>Job:</b> ${failedJobName}, attempt #${{ github.run_attempt }}`

--- a/s3-copy/README.md
+++ b/s3-copy/README.md
@@ -1,0 +1,34 @@
+# GitHub Action: Save the file archive to the S3 storage
+
+This action archives the file or directory set as input to the zip-archive
+and uploads it to the S3 storage with the path from `destination` input.
+
+# Usage
+
+## Parameters
+
+| variable             | description                                                                                                                                                      | example                 | required | default       |
+|----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------|----------|---------------|
+| s3-access-key-id     | S3 access key ID. You can find it anytime in the account description (Object storage -> Accounts -> Your account name).                                          | 1a2BCcDdEeFf            | True     | -             |
+| s3-secret-access-key | S3 secret access key. You can see it only at the time you create the account.                                                                                    | QqWwEeRrTtYyUuIiOoPprsg | True     | -             |
+| s3-region            | The region set in your S3 endpoint. You can find it in the documentation of your S3 storage, i.e. https://mcs.mail.ru/docs/ru/base/s3/quick-start/create-bucket. | ru-msck                 | False    | ru-msk        |
+| bucket               | The name of the S3 bucket.                                                                                                                                       | my-bucket               | True     | -             |
+| source               | The path to the file or directory you want to save to S3.                                                                                                        | my/file/path.txt        | True     | -             |
+| destination          | The path in the bucket with the file name. If you want to store the file in the bucket root, destination must be the file name.                                  | my/directory            | True     | -             |
+| endpoint             | The URL of your S3 storage to get the access to the uploaded files without protocol prefix.                                                                      | amazon.com              | False    | hb.bizmrg.com |
+
+
+## Example
+
+```YAML
+- name: Sync artifacts
+        uses: tarantool/actions/s3-copy@master
+        with:
+          s3-access-key-id: ${{ secrets.MY_KEY_ID }} 
+          s3-secret-access-key: ${{ secrets.MY_SECRET_KEY }}
+          s3-region: ru-msk
+          source: /home/github/_tmp/_workdir/my_artifacts
+          destination: dir/file.tar.gz
+          bucket: my_bucket
+          endpoint: hb.bizmrg.com
+```

--- a/s3-copy/action.yml
+++ b/s3-copy/action.yml
@@ -1,0 +1,63 @@
+name: Copy the files from the runner to the S3 bucket
+description: Copy the files from the runner to the S3 bucket
+
+inputs:
+  s3-access-key-id:
+    description: >
+      S3 access key ID. You can find it anytime in the account description
+      (Object storage -> Accounts -> Your account name).
+    required: true
+  s3-secret-access-key:
+    description: >
+      S3 secret access key. You can see it only at the time you create the
+      account.
+    required: true
+  s3-region:
+    description: >
+      The region set in your S3 endpoint. You can find it in the documentation
+      of your S3 storage, i.e.
+      https://mcs.mail.ru/docs/ru/base/s3/quick-start/create-bucket.
+    required: false
+    default: ru-msk
+  bucket:
+    description: The name of the S3 bucket.
+    required: true
+  source:
+    description: The path to the file or directory you want to save to S3.
+    required: true
+  destination:
+    description: >
+      The path in the bucket with the file name. If you want to store the file
+      in the bucket root, destination must be the file name.
+    required: true
+  endpoint:
+    description: >
+      The URL of your S3 storage to get the access to the uploaded files without protocol prefix.
+    required: false
+    default: hb.bizmrg.com
+
+runs:
+  using: composite
+  steps:
+    - name: Upload the file to S3 if the input file exists
+      shell: bash
+      run: |
+        if [[ ! -e ${{ inputs.source }} ]]; then
+          exit 0
+        fi
+        
+        bucket=${{ inputs.bucket }}
+        contentType="application/x-compressed-tar"
+        dateValue=`date -R`
+        resource=${{ inputs.destination }}
+        stringToSign="PUT\n\n${contentType}\n${dateValue}\n/${bucket}/${resource}"
+        s3Key='${{ inputs.s3-access-key-id }}'
+        s3Secret='${{ inputs.s3-secret-access-key }}'
+        signature=`echo -en ${stringToSign} | openssl sha1 -hmac ${s3Secret} -binary | base64`
+        
+        curl -X PUT -T "${{ inputs.source }}" \
+          -H "Host: ${bucket}.hb.bizmrg.com" \
+          -H "Date: ${dateValue}" \
+          -H "Content-Type: ${contentType}" \
+          -H "Authorization: AWS ${s3Key}:${signature}" \
+          https://${bucket}.hb.bizmrg.com/${resource}


### PR DESCRIPTION
get-job-id: add the action to get job ID

There are several situations when we need the job ID, but the GitHub
doesn't give the context with the job ID. This patch adds the action
to get the job ID from the jobs' context (info about all the jobs in the
run) with job name and run attempt.

Resolves #56 
_______

s3-copy: add action to save files to S3

This patch adds the s3-copy action to save files, i.e. job artifacts, to the S3 storage with the predictable path for easy access via the link.

Part of tarantool/multivac#116