### PR TITLE
get-job-id: fix for ChristopherHX/github-act-runner

### DIFF
--- a/get-job-id/action.yml
+++ b/get-job-id/action.yml
@@ -23,21 +23,17 @@ runs:
   steps:
     - name: Get job data
       shell: bash
-      env:
-        CURL_COMMAND: |-
-          curl --location \
-            --fail \
-            --silent \
-            --show-error \
-            --retry 5 \
-            --retry-delay 5
-        API_RUNS: >-
-          https://api.github.com/repos/${{ github.repository }}/actions/runs
       run: |
         echo 'Fetching job data'
         echo 'JOB_CONTEXT<<EOF' >> $GITHUB_ENV
-        ${{ env.CURL_COMMAND }} -H 'authorization: Bearer ${{ github.token }}' \
-          ${{ env.API_RUNS }}/${{ github.run_id }}/jobs >> $GITHUB_ENV
+        curl --location \
+          --fail \
+          --silent \
+          --show-error \
+          --retry 5 \
+          --retry-delay 5 \
+          --header 'authorization: Bearer ${{ github.token }}' \
+          https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs >> $GITHUB_ENV
         echo 'EOF' >> $GITHUB_ENV
 
     - name: Get job ID
@@ -52,7 +48,7 @@ runs:
           if (jobName == "${{ github.job }} ()") {
             jobName = "${{ github.job }}"
           }
-            
+          
           // Try to find the job ID by its name.
           // In matrix workflows will work only if exact name was provided
           // in `job-name` input.


### PR DESCRIPTION
It looks like `ChristopherHX/github-act-runner` doesn't fully support the YAML syntax (chomping indicators as >-, |-) and `get-job-id` action failed on 'Get job data' step. The patch simplifies the step and fixes the issue.

Closes tarantool/tarantool-qa#89