### PR TITLE
prepare-checkout: delete stale origin references

### DIFF
--- a/prepare-checkout/README.md
+++ b/prepare-checkout/README.md
@@ -4,6 +4,20 @@ This action creates and checks out an empty detached commit.
 It helps subsequent [`actions/checkout`](https://github.com/actions/checkout) action
 correctly clean the workspace.
 
+By default, it also deletes stale references associated with `origin`, which
+helps check out the repository without errors like this:
+```
+error: cannot lock ref 'refs/remotes/origin/<repo>/<branch>': 'refs/remotes/origin/<repo>' exists; cannot create 'refs/remotes/origin/<repo>/<branch>'
+ ! [new branch]        <repo>/<branch> -> origin/<repo>/<branch>  (unable to update local ref)
+```
+
+## Parameters
+
+- `prune` — delete stale references associated with `origin`. This will
+not affect local branches, and it will not change anything remote, but it will
+update the local references to remote branches. Submodules are affected as well.
+Default: `true`.
+
 ## Usage
 
 Add the following line to your workflow before the `actions/checkout` action:

--- a/prepare-checkout/action.yml
+++ b/prepare-checkout/action.yml
@@ -1,9 +1,25 @@
 ---
 name: 'Prepare workspace for checkout'
 description: 'Prepare workspace for the actions/checkout action'
+
+inputs:
+  prune:
+    description: >
+      Delete stale references associated with `origin`. This will not affect
+      local branches, and it will not change anything remote, but it will update
+      the local references to remote branches. Submodules are affected as well
+    required: false
+    default: 'true'
+
 runs:
   using: 'composite'
   steps:
+    - run: >
+        git remote prune origin &&
+        git submodule foreach --recursive 'git remote prune origin' || :
+      if: inputs.prune == 'true'
+      shell: bash
+
     - run: |
         set -e
         git checkout -f \


### PR DESCRIPTION
This patch adds one more step to the action to delete stale references associated with `origin`. This will not affect local branches, and it will not change anything remote, but it will update the local references to remote branches to avoid errors like this:

    error: cannot lock ref 'refs/remotes/origin/<repo>/<branch>': 'refs/remotes/origin/<repo>' exists; cannot create 'refs/remotes/origin/<repo>/<branch>'
     ! [new branch] <repo>/<branch> -> origin/<repo>/<branch> (unable to update local ref)

However, this can be disabled via the new `prune` option, just set it to `false`.

Note that submodules are affected as well.