### PR TITLE
actions: bump versions to use Node.js 20

### DIFF
--- a/.github/workflows/yaml-lint.yml
+++ b/.github/workflows/yaml-lint.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: YAML Lint and Annotate
-        uses: Staffbase/yamllint-action@v1.1.0
+        uses: Staffbase/yamllint-action@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           target-path: .

--- a/check-module-version/action.yml
+++ b/check-module-version/action.yml
@@ -21,12 +21,12 @@ runs:
   using: composite
   steps:
     - name: Clone the module
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         submodules: 'recursive'
 
     - name: Setup tarantool
-      uses: tarantool/setup-tarantool@v2
+      uses: tarantool/setup-tarantool@v3
       with:
         tarantool-version: '2.10'
 

--- a/get-job-id/action.yml
+++ b/get-job-id/action.yml
@@ -41,7 +41,7 @@ runs:
 
     - name: Get job ID
       id: get-job-id
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           const jobContext = ${{ env.JOB_CONTEXT }}

--- a/get-pr-info/action.yml
+++ b/get-pr-info/action.yml
@@ -51,7 +51,7 @@ runs:
         Fetch information about pull request #${{ inputs.pull_request_number }} 
         in ${{ inputs.repository }}
       id: get-info
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       continue-on-error: false
       with:
         github-token: ${{ inputs.token }}

--- a/remove-git-ref/action.yml
+++ b/remove-git-ref/action.yml
@@ -22,7 +22,7 @@ runs:
   using: composite
   steps:
     - name: Remove reference ${{ inputs.ref }} from ${{ inputs.repository }}
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       continue-on-error: true
       with:
         github-token: ${{ inputs.token }}

--- a/report-job-status/action.yml
+++ b/report-job-status/action.yml
@@ -51,7 +51,7 @@ runs:
 
     - name: Compose message about job failure
       id: compose-message
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         script: |
           const baseUrl = "https://github.com"

--- a/update-submodule/action.yml
+++ b/update-submodule/action.yml
@@ -80,7 +80,7 @@ runs:
       uses: tarantool/actions/prepare-checkout@master
 
     - name: Checkout the target repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         token: ${{ inputs.github_token }}
         repository: ${{ inputs.repository }}
@@ -115,7 +115,7 @@ runs:
     - name: Create a pull request against the main branch
       if: inputs.create_pr == 'true' &&
         steps.create-branch.outputs.status != 'nothing-to-commit'
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       with:
         github-token: ${{ inputs.github_token }}
         script: |


### PR DESCRIPTION
Eliminate the following GitHub warning about deprecated Node.js:

    Node.js 16 actions are deprecated.
    Please update the following actions to use Node.js 20